### PR TITLE
fix: add empty user-agent to avoid 403

### DIFF
--- a/all/plantuml_connection/__init__.py
+++ b/all/plantuml_connection/__init__.py
@@ -133,7 +133,10 @@ class PlantUML(object):
         """
         url = self.get_url(plantuml_text)
         try:
-            request = Request(url)
+            headers = {
+                "User-Agent": ""
+            }
+            request = Request(url, headers=headers)
             openurl = urlopen(request)
             http_headers = openurl.info()
 


### PR DESCRIPTION
#2 

When we don't add an empty user agent, this is the default one used.
The default one aka `Python-urllib/3.9` is blocked by Plantuml.

So to fix the issue, I've removed the user agent.

I've lost 2 hours 😅